### PR TITLE
add automated badge assignment for drafted articles

### DIFF
--- a/flask_app/SIMS_Portal/__init__.py
+++ b/flask_app/SIMS_Portal/__init__.py
@@ -121,7 +121,7 @@ def create_app(config_class=Config):
 		@scheduler.task('cron', id='run_auto_badge_assigners', hour='17')
 		def run_auto_badge_assigners():
 			with scheduler.app.app_context():
-				from SIMS_Portal.main.utils import heartbeats, auto_badge_assigner_big_wig, auto_badge_assigner_maiden_voyage, auto_badge_assigner_self_promoter, auto_badge_assigner_polyglot, auto_badge_assigner_autobiographer, auto_badge_assigner_world_traveler, auto_badge_assigner_edward_tufte, auto_badge_assigner_old_salt
+				from SIMS_Portal.main.utils import heartbeats, auto_badge_assigner_big_wig, auto_badge_assigner_maiden_voyage, auto_badge_assigner_self_promoter, auto_badge_assigner_polyglot, auto_badge_assigner_autobiographer, auto_badge_assigner_world_traveler, auto_badge_assigner_edward_tufte, auto_badge_assigner_old_salt, auto_badge_assigner_eratosthenes, auto_badge_assigner_super_scholar, auto_badge_assigner_teaching_moment
 				
 				auto_badge_assigner_maiden_voyage()
 				auto_badge_assigner_big_wig()
@@ -131,6 +131,9 @@ def create_app(config_class=Config):
 				auto_badge_assigner_edward_tufte()
 				auto_badge_assigner_world_traveler()
 				auto_badge_assigner_old_salt()
+				auto_badge_assigner_eratosthenes()
+				auto_badge_assigner_super_scholar()
+				auto_badge_assigner_teaching_moment()
 				heartbeats('run_auto_badge_assigners', 'https://uptime.betterstack.com/api/v1/heartbeat/QWvz7BCEoLnpKeCFMFbK3d2a')
 		
 		@scheduler.task('cron', id='run_set_user_inactive', day_of_week='thu', hour=9, timezone='America/New_York')

--- a/flask_app/SIMS_Portal/main/routes.py
+++ b/flask_app/SIMS_Portal/main/routes.py
@@ -39,7 +39,8 @@ from SIMS_Portal.main.utils import (
 	auto_badge_assigner_self_promoter, auto_badge_assigner_polyglot,
 	auto_badge_assigner_autobiographer, auto_badge_assigner_jack_of_all_trades,
 	auto_badge_assigner_edward_tufte, auto_badge_assigner_world_traveler,
-	auto_badge_assigner_old_salt, user_info_by_ns
+	auto_badge_assigner_old_salt, auto_badge_assigner_eratosthenes,
+	auto_badge_assigner_super_scholar, auto_badge_assigner_teaching_moment, user_info_by_ns
 )
 from SIMS_Portal.users.forms import AssignProfileTypesForm, RegionalFocalPointForm
 from SIMS_Portal.users.utils import (

--- a/flask_app/SIMS_Portal/templates/layout.html
+++ b/flask_app/SIMS_Portal/templates/layout.html
@@ -181,8 +181,11 @@
 										</div>
 									</div>
 								</li>
-
-
+								{% if '/about' in request.path %}
+								<li class="nav-item-bottom px-2 Montserrat"><button type="button" class="btn btn-light">About</button></li>
+								{% else %}
+								<li class="nav-item-bottom px-2 Montserrat"><a class="nav-link text-light" href="/about">About</a></li>
+								{% endif %}
 								{% if '/emergencies/all' in request.path %}
 								<li class="nav-item-bottom px-2 Montserrat"><button type="button" class="btn btn-light">Emergencies</button></li>
 								{% else %}


### PR DESCRIPTION
- Added three methods to automatically assign existing badges based on the number of guides authored.
  - **Teaching Moment**: 1 guide or more
  - **Super Scholar**: 3 guides or more
  - **Eratosthenes:** 5 guides or more
- Integrated these methods into the existing `run_auto_badge_assigners` function to automate badge assignment.
- The automated badge assignment will run as part of the existing process, triggered by the scheduled cron job.

Resolves #97