### PR TITLE
Remove public acronym submission functionality

### DIFF
--- a/flask_app/SIMS_Portal/templates/acronyms.html
+++ b/flask_app/SIMS_Portal/templates/acronyms.html
@@ -23,7 +23,9 @@
                 </div>
                 <div class="col-md-6 text-end">
                     <div class="">
-                        <a href='/submit_acronym'><button class='btn btn-danger btn-lg float-right'>Add Acronym</button></a>
+                        {% if user_info is not none and user_info.id > 0 %}
+                        <a href='/submit_acronym/member'><button class='btn btn-danger btn-lg float-right'>Add Acronym</button></a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/flask_app/SIMS_Portal/templates/acronyms_search.html
+++ b/flask_app/SIMS_Portal/templates/acronyms_search.html
@@ -23,7 +23,9 @@
                 </div>
                 <div class="col-md-6 text-end">
                     <div class="">
-                        <a href='/submit_acronym'><button class='btn btn-danger btn-lg float-right'>Add Acronym</button></a>
+                        {% if user_info is not none and user_info.id > 0 %}
+                        <a href='/submit_acronym/member'><button class='btn btn-danger btn-lg float-right'>Add Acronym</button></a>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -211,7 +213,11 @@
                 </tbody>
             </table>
             {% else %}
-            <h5 class="Montserrat text-dark">Either you just discovered a new acronym or it hasn't been added. <a href="/submit_acronym">Any interest in submitting it?</a></h5>
+                {% if user_info is not none and user_info.id > 0 %}
+                <h5 class="Montserrat text-dark">Either you just discovered a new acronym or it hasn't been added. <a href="/submit_acronym/member">Any interest in submitting it?</a></h5>
+                {% else %}
+                <h5 class="Montserrat text-dark">Either you just discovered a new acronym or it hasn't been added.</h5>
+                {% endif %}
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
- Prevent non-registered users from submitting acronyms.
- Only registered members can submit acronym requests now.
- Removed public access to acronym submission functionality.

Resolves #131